### PR TITLE
[ENH] Patch info.py to match requirements.txt

### DIFF
--- a/tedana/info.py
+++ b/tedana/info.py
@@ -27,6 +27,7 @@ DOWNLOAD_URL = (
 REQUIRES = [
     'numpy',
     'scikit-learn',
+    'mdp',
     'nilearn',
     'nibabel>=2.1.0',
     'pybids>=0.4.0',


### PR DESCRIPTION
I noticed when trying to install `tedana` locally via `pip install https://github.com/me-ica/tedana/tarball/master` that there was an error. This error didn't occur if you install the modules in `requirements.txt` first. 

I think this is due to divergent listed requirements between `tedana.info.REQUIRES` and `requirements.txt`. This is just a small patch to make sure they align!