### PR TITLE
modifiation of setup.py to properly install all reporting directories

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -31,6 +31,8 @@ def main():
     pkg_data = {
         'tedana': [
             'tests/data/*',
+            'reporting/data/*',
+            'reporting/data/html/*',
         ]
     }
 


### PR DESCRIPTION
This request is to make a change to setup.py so that all directories that are part of the new dynamic reporting features get properly installed when installing tedana. Otherwise only the reporting directory and the .py files directly underneath it get copied, but not the data subdirectory or the data/html subdirectory.