### PR TITLE
Use relative path for static figures on dynamic reports

### DIFF
--- a/tedana/reporting/dynamic_figures.py
+++ b/tedana/reporting/dynamic_figures.py
@@ -30,7 +30,7 @@ tap_callback_jscode = """
 
         // Image Below Plots
         div.text = ""
-        var line = "<span><img src='" + outdir + "/figures/comp_"+selected_padded_forIMG+".png'" +
+        var line = "<span><img src='./figures/comp_"+selected_padded_forIMG+".png'" +
             " alt='Component Map'><span>\\n";
         console.log('Linea: ' + line)
         var text = div.text.concat(line);


### PR DESCRIPTION
<!---
This is a suggested pull request template for tedana.
It's designed to capture information we've found to be useful in reviewing pull requests.

If there is other information that would be helpful to include, please don't hesitate to add it!

Please also label your pull request with the relevant tags.
See here for more information and a list of available options:
https://github.com/ME-ICA/tedana/blob/master/CONTRIBUTING.md#pull-requests
-->

<!-- Please indicate after the # which issue you're closing with this PR.
This is helpful for the maintainers AND will magically close the issue when this
pull request is merged!
https://help.github.com/articles/closing-issues-using-keywords -->
Closes none.

<!-- Please give a brief overview of what has changed in the PR.
If you're not sure what to write, consider it a note to the maintainers to indicate
what they should be looking for when they review the pull request. -->
Changes proposed in this pull request:

- Modifies the JS code of the dynamic reports to use relative paths when displaying static figures. It drops the use of `outdir`; i.e. the absolute path to the output folder.
